### PR TITLE
Identify and update tags for multi-event emails

### DIFF
--- a/src/emailToEvents.ts
+++ b/src/emailToEvents.ts
@@ -222,18 +222,21 @@ export async function processNewEmail(email: ParsedMail) {
     if (result === "dormspam-with-event") {
       console.log("Email was successfully processed and event(s) were extracted. Adding tags...");
 
-      // Fetching the event that should've been created if event(s) were extracted to add tags
-      const event = await prisma.event.findFirst({
+      // Fetching the event(s) that should've been created if event(s) were extracted to add tags
+      const events = await prisma.event.findMany({
         where: {
           fromEmailId: email.messageId
         }
       });
-      if (event === null) {
-        console.error("Event from email was not found in the database. Exiting...");
+      if (events === null) {
+        console.error("Event(s) from email were not found in the database. Exiting...");
         return;
       }
-      const tags = await addTagsToEvent(event);
-      await updateEventTags(prisma, event, tags);
+
+      for (const event of events) {
+        const tags = await addTagsToEvent(event);
+        await updateEventTags(prisma, event, tags);
+      }
     }
   }
   finally {

--- a/src/emailToEvents.ts
+++ b/src/emailToEvents.ts
@@ -228,7 +228,7 @@ export async function processNewEmail(email: ParsedMail) {
           fromEmailId: email.messageId
         }
       });
-      if (events === null) {
+      if (events.length === 0) {
         console.error("Event(s) from email were not found in the database. Exiting...");
         return;
       }

--- a/src/scripts/testEventToTagsPrompt.ts
+++ b/src/scripts/testEventToTagsPrompt.ts
@@ -13,8 +13,8 @@ export async function main() {
   });
   try {
     const eventName = await readlineInterface.question("Event name: ");
-    const getAllEvents = await readlineInterface.question("Get all events? (y/n): ")
-    if (getAllEvents === "y") {
+    const getAllEvents = await readlineInterface.question("Get all events? (y/N): ")
+    if (getAllEvents.toLowerCase() === "y") {
       const events = await prisma.event.findMany({
         where: { title: { contains: eventName, mode: "insensitive" } }
       });

--- a/src/scripts/testEventToTagsPrompt.ts
+++ b/src/scripts/testEventToTagsPrompt.ts
@@ -13,11 +13,25 @@ export async function main() {
   });
   try {
     const eventName = await readlineInterface.question("Event name: ");
-    const event = await prisma.event.findFirstOrThrow({
-      where: { title: { contains: eventName, mode: "insensitive" } }
-    });
-    console.log(event);
-    console.log(await addTagsToEvent(event));
+    const getAllEvents = await readlineInterface.question("Get all events? (y/n): ")
+    if (getAllEvents === "y") {
+      const events = await prisma.event.findMany({
+        where: { title: { contains: eventName, mode: "insensitive" } }
+      });
+      if (events.length === 0) {
+        throw Error(`No events with provided event name ${eventName} were found.`)
+      }
+      for (const event of events) {
+        console.log(event)
+        console.log(await addTagsToEvent(event))
+      }
+    } else {
+      const event = await prisma.event.findFirstOrThrow({
+        where: { title: { contains: eventName, mode: "insensitive" } }
+      });
+      console.log(event);
+      console.log(await addTagsToEvent(event));
+    }
   } finally {
     readlineInterface.close();
     await prisma.$disconnect();


### PR DESCRIPTION
An email can generate multiple events. For example, "[LDSSA] General Conference Watch Party" generated four events because there were four watch party sessions listed in one email.

Previously, only the first event obtained from an email was used to identify and update tags, so some events would be missing tags. This PR identifies and updates tags for every event extracted from an email.