### PR TITLE
Set fromEmailId field of new events to the messageId of the current email

### DIFF
--- a/src/emailToEvents.ts
+++ b/src/emailToEvents.ts
@@ -496,7 +496,7 @@ async function processMail(
           location: event.location,
           organizer: event.organizer,
           duration: event.duration,
-          fromEmail: { connect: { messageId: rootMessageId } },
+          fromEmail: { connect: { messageId: messageId } },
           text
         };
         for (const [title, distance] of knn) {


### PR DESCRIPTION
As mentioned in #2, we observe some events from emails are not found in the database, even after events were successfully extracted. We cannot subsequently tag events.

Untagged events appear to mostly, if not all, come from bumped emails. When [creating new events](https://github.com/DormSoup/dormsoup-daemon/blob/main/src/emailToEvents.ts#L499) to insert into the database, we set the `fromEmailId` field to `rootMessageId`, which is the message of the original (in reply to) email. This message id differs from the message id of the new email; however, we [search for the event](https://github.com/DormSoup/dormsoup-daemon/blob/main/src/emailToEvents.ts#L226-L230) by the message id of the new email, which does not exist in the database.

This PR updates `newEventData` to use `messageId`, referring to the message id of the current email.