### PR TITLE
Locally test email parsing without needing access to your entire email history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ sync.sh
 .DS_Store
 
 push.date
+
+*.eml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ To test, send emails to `dormdigest@scripts.mit.edu`.
 
 (You’ll need the `.env` file containing the API key and database URL from andiliu.)
 
+### (WIP) Testing Locally Without Outlook/Office365
+
+Fetch the email (`.eml` or `.txt` file) you wish to test from
+* Our example archive of dormspam emails from GitHub, located at <https://github.mit.edu/sipb/dormdigest-emails>
+* Our log of most previously saved emails, located at `/afs/sipb.mit.edu/project/dormdigest/mail_scripts/saved` (ask other SIPB members how to access AFS)
+* Download from your favorite email client. On Outlook web, click the "..." button then click on "Save as".
+
+Now run
+
+```bash
+npm run parseEmailFromFile study_break.eml
+```
+
+This script works to test event date/time parsing, but not to test tag assigning.
+
+For now, you can test the event to tags part by running `npm run testEventToTagsPrompt` as described below,
+which needs database credentials, but does not actually need you to be logged in to Outlook/Office365.
+
 ### Testing Locally
 
 First, to authenticate into your email, run:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "llm": "tsx src/llm.ts",
     "testEmailToEventsPrompt": "tsx src/scripts/testEmailToEventsPrompt.ts",
     "testEventToTagsPrompt": "tsx src/scripts/testEventToTagsPrompt.ts",
+    "parseEmailFromFile": "tsx src/scripts/parseEmailFromFile.ts",
     "deleteAllEvents": "tsx src/scripts/deleteAllEvents.ts",
     "deleteAllEmails": "tsx src/scripts/deleteAllEmails.ts",
     "oneOffTask": "tsx src/scripts/oneOffTask.ts",

--- a/src/emailToEvents.ts
+++ b/src/emailToEvents.ts
@@ -293,7 +293,7 @@ const isDormspamRegex = new RegExp(
   "ui"
 );
 
-function isDormspam(text: string): boolean {
+export function isDormspam(text: string): boolean {
   return isDormspamRegex.test(text) && !text.includes("dormsoup-ignore");
 }
 

--- a/src/llm/emailToEvents.ts
+++ b/src/llm/emailToEvents.ts
@@ -160,7 +160,7 @@ const EXTRACT_FUNCTION: ChatCompletionFunctions = {
   }
 };
 
-type NonEmptyArray<T> = [T, ...T[]];
+export type NonEmptyArray<T> = [T, ...T[]];
 
 export type ExtractFromEmailResult =
   | {

--- a/src/scripts/debugEmailParsing.ts
+++ b/src/scripts/debugEmailParsing.ts
@@ -1,0 +1,42 @@
+import assert from "assert";
+import { convert } from "html-to-text";
+import { Source, simpleParser } from "mailparser";
+
+import {
+  Event,
+  ExtractFromEmailResult,
+  NonEmptyArray,
+  extractFromEmail
+} from "../llm/emailToEvents.js";
+import { isDormspam } from "../emailToEvents.js";
+
+/**
+ * Print some debugging information (whether the message was parsed as dormspam),
+ * then parse the email to extract the events and print this.
+ *
+ * @param message The raw email content, as a Buffer or string.
+ * @returns A list of events
+ */
+export async function debugEmailToEvents(messageSource: Source): Promise<NonEmptyArray<Event>> {
+  const parsed = await simpleParser(messageSource, {
+    skipImageLinks: true,
+    skipHtmlToText: false
+  });
+  assert(parsed.html);
+
+  const text = parsed.text ?? convert(parsed.html);
+  console.log(text);
+  console.log("Is this a dormspam email?", isDormspam(text));
+  const result: ExtractFromEmailResult = await extractFromEmail(
+    parsed.subject ?? "No subject",
+    text,
+    parsed.date ?? new Date()
+  );
+  console.log("Extracted event:", result);
+  if (result.status === "admitted") {
+    const events = result.events;
+    return events;
+  } else {
+    assert(false, "The event was not successfully extracted");
+  }
+}

--- a/src/scripts/debugEmailParsing.ts
+++ b/src/scripts/debugEmailParsing.ts
@@ -2,13 +2,8 @@ import assert from "assert";
 import { convert } from "html-to-text";
 import { Source, simpleParser } from "mailparser";
 
-import {
-  Event,
-  ExtractFromEmailResult,
-  NonEmptyArray,
-  extractFromEmail
-} from "../llm/emailToEvents.js";
 import { isDormspam } from "../emailToEvents.js";
+import { Event, ExtractFromEmailResult, extractFromEmail } from "../llm/emailToEvents.js";
 
 /**
  * Print some debugging information (whether the message was parsed as dormspam),
@@ -17,7 +12,7 @@ import { isDormspam } from "../emailToEvents.js";
  * @param message The raw email content, as a Buffer or string.
  * @returns A list of events
  */
-export async function debugEmailToEvents(messageSource: Source): Promise<NonEmptyArray<Event>> {
+export async function debugEmailToEvents(messageSource: Source): Promise<Event[]> {
   const parsed = await simpleParser(messageSource, {
     skipImageLinks: true,
     skipHtmlToText: false
@@ -37,6 +32,7 @@ export async function debugEmailToEvents(messageSource: Source): Promise<NonEmpt
     const events = result.events;
     return events;
   } else {
-    assert(false, "The event was not successfully extracted");
+    console.warn("The event was not successfully extracted");
+    return [];
   }
 }

--- a/src/scripts/parseEmailFromFile.ts
+++ b/src/scripts/parseEmailFromFile.ts
@@ -1,0 +1,39 @@
+/// Parse an email from standard input, thus avoiding to authenticate to Outlook/Office365
+
+// import { addTagsToEvent } from "../llm/eventToTags";
+import { debugEmailToEvents } from "./debugEmailParsing";
+import fs from 'node:fs';
+
+async function main(): Promise<void> {
+    let filename: string;
+    // just in case
+    if (process.argv[0].includes("node")) {
+        filename = process.argv[2];
+    } else {
+        filename = process.argv[1];
+    }
+    if (filename === undefined) {
+        console.error("Usage: npm run parseEmailFromFile filename")
+        console.error("filename may be the path to an .eml file, or it may be - to read from standard input")
+        process.exit(1);
+    }
+    const file = filename === "-" ? process.stdin.fd : filename;
+    const contents = fs.readFileSync(file);
+    const events = await debugEmailToEvents(contents);
+    console.log("Done parsing event date/time!");
+    
+    console.log("Parsing tags from file is a working progress...") //:D")
+    for (const event of events) {
+        // TODO: fix this.
+        // This doesn't actually work because Event from eventToTags.ts is a prisma type
+        //   but Event from emailToEvents.ts is a custom typescript type
+        //   and they have different fields, so the output of one cannot simply be used as
+        //   input of the other, and having to query the database to debugging the tagging
+        //   is annoying and should be unnecessary since this should be testable without need of
+        //   a database...
+
+        // console.log(await addTagsToEvent(event));
+    }
+}
+
+await main();


### PR DESCRIPTION
This PR adds a new script:

```
npm run parseEmailFromFile study_break.eml
```

This is the equivallent of running:

```
npm run testEmailToEventsPrompt
```

It can help with:

1. Having more reproducible testing (simply running a command on a concrete file, rather than remembering the email subject)
2. Not requiring you to have an Office365 inbox in order to test email parsing (so @danayim03 can use this despite not having an inbox)
3. It can be more convenient to just call a command than having to follow the entire log in and search process.
4. It gives a concrete way to test with our large repertoire of emails located in `/mit/dormdigest/mail_scripts/saved` and <https://github.mit.edu/sipb/dormdigest-emails>