### PR TITLE
Upsert embedding with eventId after filtering eventIds in metadata

### DIFF
--- a/src/emailToEvents.ts
+++ b/src/emailToEvents.ts
@@ -525,8 +525,8 @@ async function processMail(
               continue outer;
             }
             if (merged === "former") {
-              upsertEmbedding(event.title, embedding, { eventIds: [eventId] });
               metadata.eventIds = metadata.eventIds.filter((id) => id !== eventId);
+              upsertEmbedding(event.title, embedding, { eventIds: [eventId] });
               if (metadata.eventIds.length === 0) deleteEmbedding(title);
               console.log("Event ", event, " updates previous event ", otherEvent);
               await prisma.event.update({


### PR DESCRIPTION
Some events are duplicated (#17).

Previously, our deduplication method filters out `eventId` from the embedding metadata after updating the embedding with `eventId`, should we detect a duplicate event (e.g. `merged === former`). Thus `eventId` no longer exists in the embedding corresponding to a particular event title. Future events may not detect a duplicate among its k nearest neighbors.

This PR updates the embedding metadata with `eventId` after the filter.

See file '1022488444-[OPENING TOMORROW] MACBETH.log' in `/home/dormsoup/daemon/logs/sipb-mail-scripts` on the server for example logs during a failed deduplication, where duplicates do not exist among the k nearest neighbors for a particular event.